### PR TITLE
API for bseq to be more like ExpSeq

### DIFF
--- a/RootSeq.m
+++ b/RootSeq.m
@@ -159,6 +159,39 @@ classdef RootSeq < ExpSeqBase
             % with the sequence as the argument.
             self.after_branch_cbs{end + 1} = cb;
         end
+        %% Methods that call topLevel methods to allow for more convenient and linear API usage
+        % See methods in ExpSeq for the arguments required for each.
+        function bseq = newBasicSeq(self, varargin)
+            bseq = newBasicSeq(self.topLevel, varargin{:});
+        end
+
+        function addTTLMgr(self, varargin)
+            addTTLMgr(self.topLevel, varargin{:});
+        end
+
+        function disableChannel(self, varargin)
+            disableChannel(self.topLevel, varargin{:});
+        end
+
+        function res = checkChannelDisabled(self, varargin)
+            res = checkChannelDisabled(self.topLevel, varargin{:});
+        end
+
+        function self = regBeforeStart(self, varargin)
+            regBeforeStart(self.topLevel, varargin{:});
+        end
+
+        function self = regAfterEnd(self, varargin)
+            regAfterEnd(self.topLevel, varargin{:});
+        end
+
+        function val = get_global(self, varargin)
+            val = get_global(self.topLevel, varargin{:});
+        end
+
+        function set_global(self, varargin)
+            set_global(self.topLevel, varargin{:});
+        end
     end
 
     methods(Access=protected)


### PR DESCRIPTION
Wrote some API for making a RootSeq more like an ExpSeq by calling topLevel methods. You should check for style and whether you want to add more/remove some methods (not sure about whether we should have the disableChannel methods, but I think the get_global and set_global would be nice). I also inlined newBasicSeq, so that I didn't need to repeat the logic for whether cb exists or not. This might not be the best idea...